### PR TITLE
Submachines

### DIFF
--- a/Core/Stateflows/Common/Classes/InMemoryStorage.cs
+++ b/Core/Stateflows/Common/Classes/InMemoryStorage.cs
@@ -12,17 +12,25 @@ namespace Stateflows.Common.Classes
 
         public Task<StateflowsContext> Hydrate(BehaviorId id)
         {
-            if (!Contexts.TryGetValue(id.GetHashCode(), out var context))
+            lock (Contexts)
             {
-                context = new StateflowsContext() { Id = id };
-            }
+                if (!Contexts.TryGetValue(id.GetHashCode(), out var context))
+                {
+                    context = new StateflowsContext() { Id = id };
+                }
 
-            return Task.FromResult(context);
+                return Task.FromResult(context);
+            }
         }
 
         public Task Dehydrate(StateflowsContext context)
         {
-            Contexts[context.Id.GetHashCode()] = context;
+            var hash = context.Id.GetHashCode();
+
+            lock (Contexts)
+            {
+                Contexts[hash] = context;
+            }
 
             return Task.CompletedTask;
         }

--- a/Core/Stateflows/Common/Events/Exit.cs
+++ b/Core/Stateflows/Common/Events/Exit.cs
@@ -1,0 +1,5 @@
+﻿namespace Stateflows.Common.Events
+{
+    public sealed class Exit : Event
+    { }
+}

--- a/Core/Stateflows/StateMachines/Context/Classes/EventContext.cs
+++ b/Core/Stateflows/StateMachines/Context/Classes/EventContext.cs
@@ -6,7 +6,7 @@ using Stateflows.StateMachines.Inspection.Interfaces;
 
 namespace Stateflows.StateMachines.Context.Classes
 {
-    internal class EventContext<TEvent> : BaseContext, IEventContext<TEvent>, IEventInspectionContext<TEvent>
+    internal class EventContext<TEvent> : BaseContext, IEventContext<TEvent>, IEventInspectionContext<TEvent>, IRootContext
         where TEvent : Event
     {
         IStateMachineContext IEventContext<TEvent>.StateMachine => StateMachine;

--- a/Core/Stateflows/StateMachines/Context/Classes/RootContext.cs
+++ b/Core/Stateflows/StateMachines/Context/Classes/RootContext.cs
@@ -122,12 +122,19 @@ namespace Stateflows.StateMachines.Context.Classes
             }
         }
 
+        public bool ForceConsumed
+        {
+            get => Context.Values.TryGetValue(Constants.ForceConsumed, out var consumed) && (bool)consumed;
+            set => Context.Values[Constants.ForceConsumed] = value;
+        }
+
         internal void ClearTemporaryInternalValues()
         {
             Context.Values.Remove(Constants.State);
             Context.Values.Remove(Constants.Event);
             Context.Values.Remove(Constants.SourceState);
             Context.Values.Remove(Constants.TargetState);
+            Context.Values.Remove(Constants.ForceConsumed);
         }
 
         public async Task Send<TEvent>(TEvent @event)

--- a/Core/Stateflows/StateMachines/Context/Classes/StateValues.cs
+++ b/Core/Stateflows/StateMachines/Context/Classes/StateValues.cs
@@ -10,6 +10,33 @@ namespace Stateflows.StateMachines.Context.Classes
 
         public Dictionary<string, string> Values { get; set; } = new Dictionary<string, string>();
 
+        public bool TryGetSubmachineId(out StateMachineId submachineId)
+        {
+            if (
+                InternalValues.TryGetValue(Constants.SubmachineId, out var submachineIdObj) &&
+                submachineIdObj != null
+            )
+            {
+                submachineId = (StateMachineId)submachineIdObj;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public void SetSubmachineId(StateMachineId? value)
+        {
+            if (value != null)
+            {
+                InternalValues[Constants.SubmachineId] = value;
+            }
+            else
+            {
+                InternalValues.Remove(Constants.SubmachineId);
+            }
+        }
+
         private List<string> timeEventIds = null;
 
         [JsonIgnore]

--- a/Core/Stateflows/StateMachines/Engine/Executor.cs
+++ b/Core/Stateflows/StateMachines/Engine/Executor.cs
@@ -115,7 +115,7 @@ namespace Stateflows.StateMachines.Engine
             return stateDescriptor;
         }
 
-        public async Task<bool> Hydrate(RootContext context)
+        public async Task<bool> HydrateAsync(RootContext context)
         {
             Context = context;
             Context.Executor = this;
@@ -125,7 +125,7 @@ namespace Stateflows.StateMachines.Engine
             return true;
         }
 
-        public async Task<RootContext> Dehydrate()
+        public async Task<RootContext> DehydrateAsync()
         {
             Debug.Assert(Context != null, $"Context is unavailable. Is state machine '{Graph.Name}' already dehydrated?");
 
@@ -148,7 +148,7 @@ namespace Stateflows.StateMachines.Engine
             }
         }
 
-        public async Task<bool> Initialize(InitializationRequest @event)
+        public async Task<bool> InitializeAsync(InitializationRequest @event)
         {
             Debug.Assert(Context != null, $"Context is unavailable. Is state machine '{Graph.Name}' hydrated?");
 
@@ -157,11 +157,28 @@ namespace Stateflows.StateMachines.Engine
                 await DoInitializeAsync(@event);
 
                 await DoInitializeCascadeAsync(Graph.InitialVertex);
-                    
+
                 return true;
             }
 
             return false;
+        }
+
+        public async Task ExitAsync()
+        {
+            Debug.Assert(Context != null, $"Context is unavailable. Is state machine '{Graph.Name}' hydrated?");
+
+            if (Initialized)
+            {
+                var currentStack = await GetVerticesStackAsync(false);
+
+                foreach (var vertex in currentStack)
+                {
+                    await DoExitAsync(vertex);
+                }
+
+                Context.StatesStack.Clear();
+            }
         }
 
         private async Task DoInitializeCascadeAsync(Vertex vertex)

--- a/Core/Stateflows/StateMachines/Engine/Inspector.cs
+++ b/Core/Stateflows/StateMachines/Engine/Inspector.cs
@@ -216,6 +216,14 @@ namespace Stateflows.StateMachines.Engine
             where TEvent : Event, new()
             => Interceptors.RunSafe(i => i.BeforeProcessEventAsync(context), nameof(BeforeProcessEventAsync));
 
+        public Task AfterDispatchEventAsync<TEvent>(EventContext<TEvent> context)
+            where TEvent : Event, new()
+            => Interceptors.RunSafe(i => i.AfterDispatchEventAsync(context), nameof(AfterDispatchEventAsync));
+
+        public Task<bool> BeforeDispatchEventAsync<TEvent>(EventContext<TEvent> context)
+            where TEvent : Event, new()
+            => Interceptors.RunSafe(i => i.BeforeDispatchEventAsync(context), nameof(BeforeDispatchEventAsync));
+
         public Task OnStateMachineInitializeExceptionAsync(StateMachineActionContext context, Exception exception)
             => Task.WhenAll(
                 ExceptionHandlers.RunSafe(h => h.OnStateMachineInitializeExceptionAsync(context, exception), nameof(OnStateMachineInitializeExceptionAsync)),

--- a/Core/Stateflows/StateMachines/Engine/Observer.cs
+++ b/Core/Stateflows/StateMachines/Engine/Observer.cs
@@ -166,7 +166,9 @@ namespace Stateflows.StateMachines.Engine
                     context.TryLocateStateMachine(submachineId, out var stateMachine)
                 )
                 {
-                    return !await stateMachine.SendAsync(context.Event);
+                    var consumed = await stateMachine.SendAsync(context.Event);
+                    (context as IRootContext).Context.ForceConsumed = consumed;
+                    return !consumed;
                 }
             }
 

--- a/Core/Stateflows/StateMachines/Engine/Processor.cs
+++ b/Core/Stateflows/StateMachines/Engine/Processor.cs
@@ -67,6 +67,13 @@ namespace Stateflows.StateMachines.Engine
 
                                 await executor.Observer.AfterProcessEventAsync(eventContext);
                             }
+                            else
+                            {
+                                if (executor.Context.ForceConsumed)
+                                {
+                                    result = true;
+                                }
+                            }
                         }
 
                         await executor.Observer.AfterDispatchEventAsync(eventContext);

--- a/Core/Stateflows/StateMachines/EventHandlers/ExitHandler.cs
+++ b/Core/Stateflows/StateMachines/EventHandlers/ExitHandler.cs
@@ -1,24 +1,23 @@
 ﻿using System.Threading.Tasks;
 using Stateflows.Common;
+using Stateflows.Common.Events;
 using Stateflows.StateMachines.Extensions;
 using Stateflows.StateMachines.Inspection.Interfaces;
 
 namespace Stateflows.StateMachines.EventHandlers
 {
-    internal class InitializationHandler : IStateMachineEventHandler
+    internal class ExitHandler : IStateMachineEventHandler
     {
-        public string EventName => EventInfo<InitializationRequest>.Name;
+        public string EventName => EventInfo<Exit>.Name;
 
         public async Task<bool> TryHandleEventAsync<TEvent>(IEventInspectionContext<TEvent> context)
             where TEvent : Event, new()
         {
-            if (context.Event is InitializationRequest)
+            if (context.Event is Exit)
             {
                 var executor = context.StateMachine.GetExecutor();
 
-                var initialized = await executor.InitializeAsync(context.Event as InitializationRequest);
-
-                (context.Event as InitializationRequest).Respond(new InitializationResponse() { InitializationSuccessful = initialized });
+                await executor.ExitAsync();
 
                 return true;
             }

--- a/Core/Stateflows/StateMachines/Events/Completion.cs
+++ b/Core/Stateflows/StateMachines/Events/Completion.cs
@@ -1,5 +1,5 @@
-﻿using Stateflows.StateMachines.Registration;
-using Stateflows.Common;
+﻿using Stateflows.Common;
+using Stateflows.StateMachines.Registration;
 
 namespace Stateflows.StateMachines.Events
 {

--- a/Core/Stateflows/StateMachines/Extensions/BuilderExtensions.cs
+++ b/Core/Stateflows/StateMachines/Extensions/BuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace Stateflows.StateMachines.Extensions
             }
         }
 
-        public static void AddStateEvents<TState, TReturn>(this IStateBuilderBase<TReturn> builder)
+        public static void AddStateEvents<TState, TReturn>(this IStateEventsBuilderBase<TReturn> builder)
             where TState : State
         {
             if (typeof(State).GetMethod(Constants.OnEntryAsync).IsOverridenIn<TState>())

--- a/Core/Stateflows/StateMachines/Interfaces/IStateMachineInterceptor.cs
+++ b/Core/Stateflows/StateMachines/Interfaces/IStateMachineInterceptor.cs
@@ -10,5 +10,7 @@ namespace Stateflows.StateMachines
         Task BeforeDehydrateAsync(IStateMachineActionContext context);
         Task<bool> BeforeProcessEventAsync(IEventContext<Event> context);
         Task AfterProcessEventAsync(IEventContext<Event> context);
+        Task<bool> BeforeDispatchEventAsync(IEventContext<Event> context);
+        Task AfterDispatchEventAsync(IEventContext<Event> context);
     }
 }

--- a/Core/Stateflows/StateMachines/Models/Vertex.cs
+++ b/Core/Stateflows/StateMachines/Models/Vertex.cs
@@ -24,5 +24,8 @@ namespace Stateflows.StateMachines.Models
         public Vertex InitialVertex { get; set; }
         public Dictionary<string, Vertex> Vertices { get; set; } = new Dictionary<string, Vertex>();
         public List<string> DeferredEvents { get; set; } = new List<string>();
+
+        public Dictionary<string, object> SubmachineInitialValues { get; set; }
+        public string SubmachineName { get; set; }
     }
 }

--- a/Core/Stateflows/StateMachines/Registration/Builders/CompositeStateBuilder.cs
+++ b/Core/Stateflows/StateMachines/Registration/Builders/CompositeStateBuilder.cs
@@ -150,10 +150,10 @@ namespace Stateflows.StateMachines.Registration.Builders
             => AddInitialCompositeState(stateName, compositeStateBuildAction) as ITypedCompositeStateBuilder;
         #endregion
 
-        ICompositeStateInitialBuilder IStateBuilderBase<ICompositeStateInitialBuilder>.AddOnEntry(Func<IStateActionContext, Task> actionAsync)
+        ICompositeStateInitialBuilder IStateEventsBuilderBase<ICompositeStateInitialBuilder>.AddOnEntry(Func<IStateActionContext, Task> actionAsync)
             => AddOnEntry(actionAsync) as ICompositeStateInitialBuilder;
 
-        ICompositeStateInitialBuilder IStateBuilderBase<ICompositeStateInitialBuilder>.AddOnExit(Func<IStateActionContext, Task> actionAsync)
+        ICompositeStateInitialBuilder IStateEventsBuilderBase<ICompositeStateInitialBuilder>.AddOnExit(Func<IStateActionContext, Task> actionAsync)
             => AddOnExit(actionAsync) as ICompositeStateInitialBuilder;
 
         ICompositeStateInitialBuilder ICompositeStateBuilderBase<ICompositeStateInitialBuilder>.AddOnInitialize(Func<IStateActionContext, Task> actionAsync)
@@ -165,9 +165,6 @@ namespace Stateflows.StateMachines.Registration.Builders
         ICompositeStateBuilder IStateMachineInitialBuilderBase<ICompositeStateBuilder>.AddInitialCompositeState(string stateName, CompositeStateBuilderAction compositeStateBuildAction)
             => AddInitialCompositeState(stateName, compositeStateBuildAction);
 
-        ITypedCompositeStateBuilder ICompositeStateBuilderBase<ITypedCompositeStateBuilder>.AddOnInitialize(Func<IStateActionContext, Task> actionAsync)
-            => AddOnInitialize(actionAsync) as ITypedCompositeStateBuilder;
-
         ICompositeStateInitialBuilder IStateTransitionsBuilderBase<ICompositeStateInitialBuilder>.AddTransition<TEvent>(string targetStateName, TransitionBuilderAction<TEvent> transitionBuildAction)
             => AddTransition<TEvent>(targetStateName, transitionBuildAction) as ICompositeStateInitialBuilder;
 
@@ -177,7 +174,22 @@ namespace Stateflows.StateMachines.Registration.Builders
         ICompositeStateInitialBuilder IStateTransitionsBuilderBase<ICompositeStateInitialBuilder>.AddInternalTransition<TEvent>(TransitionBuilderAction<TEvent> transitionBuildAction)
             => AddInternalTransition<TEvent>(transitionBuildAction) as ICompositeStateInitialBuilder;
 
-        ICompositeStateInitialBuilder IStateBuilderBase<ICompositeStateInitialBuilder>.AddDeferredEvent<TEvent>()
+        ICompositeStateInitialBuilder IStateUtilsBuilderBase<ICompositeStateInitialBuilder>.AddDeferredEvent<TEvent>()
             => AddDeferredEvent<TEvent>() as ICompositeStateInitialBuilder;
+
+        ITypedCompositeStateBuilder IStateUtilsBuilderBase<ITypedCompositeStateBuilder>.AddDeferredEvent<TEvent>()
+            => AddDeferredEvent<TEvent>() as ITypedCompositeStateBuilder;
+
+        ITypedCompositeStateInitialBuilder IStateUtilsBuilderBase<ITypedCompositeStateInitialBuilder>.AddDeferredEvent<TEvent>()
+            => AddDeferredEvent<TEvent>() as ITypedCompositeStateInitialBuilder;
+
+        ITypedCompositeStateInitialBuilder IStateTransitionsBuilderBase<ITypedCompositeStateInitialBuilder>.AddTransition<TEvent>(string targetStateName, TransitionBuilderAction<TEvent> transitionBuildAction)
+            => AddTransition<TEvent>(targetStateName, transitionBuildAction) as ITypedCompositeStateInitialBuilder;
+
+        ITypedCompositeStateInitialBuilder IStateTransitionsBuilderBase<ITypedCompositeStateInitialBuilder>.AddDefaultTransition(string targetStateName, TransitionBuilderAction<Completion> transitionBuildAction)
+            => AddDefaultTransition(targetStateName, transitionBuildAction) as ITypedCompositeStateInitialBuilder;
+
+        ITypedCompositeStateInitialBuilder IStateTransitionsBuilderBase<ITypedCompositeStateInitialBuilder>.AddInternalTransition<TEvent>(TransitionBuilderAction<TEvent> transitionBuildAction)
+            => AddInternalTransition<TEvent>(transitionBuildAction) as ITypedCompositeStateInitialBuilder;
     }
 }

--- a/Core/Stateflows/StateMachines/Registration/Builders/StateBuilder.cs
+++ b/Core/Stateflows/StateMachines/Registration/Builders/StateBuilder.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Stateflows.Common;
+using Stateflows.Common.Events;
 using Stateflows.StateMachines.Events;
 using Stateflows.StateMachines.Models;
 using Stateflows.StateMachines.Context.Classes;
@@ -10,8 +12,6 @@ using Stateflows.StateMachines.Registration.Extensions;
 using Stateflows.StateMachines.Registration.Interfaces;
 using Stateflows.StateMachines.Registration.Interfaces.Base;
 using Stateflows.StateMachines.Registration.Interfaces.Internal;
-using Stateflows.Common.Events;
-using System.Collections.Generic;
 
 namespace Stateflows.StateMachines.Registration.Builders
 {
@@ -174,6 +174,36 @@ namespace Stateflows.StateMachines.Registration.Builders
 
         ISubmachineTypedStateBuilder IStateSubmachineBuilderBase<ISubmachineTypedStateBuilder>.AddSubmachine(string submachineName, Dictionary<string, object> submachineInitialValues)
             => AddSubmachine(submachineName, submachineInitialValues) as ISubmachineTypedStateBuilder;
+
+        ISubmachineStateBuilder IStateEventsBuilderBase<ISubmachineStateBuilder>.AddOnEntry(Func<IStateActionContext, Task> actionAsync)
+            => AddOnEntry(actionAsync) as ISubmachineStateBuilder;
+
+        ISubmachineStateBuilder IStateEventsBuilderBase<ISubmachineStateBuilder>.AddOnExit(Func<IStateActionContext, Task> actionAsync)
+            => AddOnExit(actionAsync) as ISubmachineStateBuilder;
+
+        ISubmachineStateBuilder IStateUtilsBuilderBase<ISubmachineStateBuilder>.AddDeferredEvent<TEvent>()
+            => AddDeferredEvent<TEvent>() as ISubmachineStateBuilder;
+
+        ISubmachineStateBuilder IStateTransitionsBuilderBase<ISubmachineStateBuilder>.AddTransition<TEvent>(string targetStateName, TransitionBuilderAction<TEvent> transitionBuildAction)
+            => AddTransition<TEvent>(targetStateName, transitionBuildAction) as ISubmachineStateBuilder;
+
+        ISubmachineStateBuilder IStateTransitionsBuilderBase<ISubmachineStateBuilder>.AddDefaultTransition(string targetStateName, TransitionBuilderAction<Completion> transitionBuildAction)
+            => AddDefaultTransition(targetStateName, transitionBuildAction) as ISubmachineStateBuilder;
+
+        ISubmachineStateBuilder IStateTransitionsBuilderBase<ISubmachineStateBuilder>.AddInternalTransition<TEvent>(TransitionBuilderAction<TEvent> transitionBuildAction)
+            => AddInternalTransition<TEvent>(transitionBuildAction) as ISubmachineStateBuilder;
+
+        ISubmachineTypedStateBuilder IStateUtilsBuilderBase<ISubmachineTypedStateBuilder>.AddDeferredEvent<TEvent>()
+            => AddDeferredEvent<TEvent>() as ISubmachineTypedStateBuilder;
+
+        ISubmachineTypedStateBuilder IStateTransitionsBuilderBase<ISubmachineTypedStateBuilder>.AddTransition<TEvent>(string targetStateName, TransitionBuilderAction<TEvent> transitionBuildAction)
+            => AddTransition<TEvent>(targetStateName, transitionBuildAction) as ISubmachineTypedStateBuilder;
+
+        ISubmachineTypedStateBuilder IStateTransitionsBuilderBase<ISubmachineTypedStateBuilder>.AddDefaultTransition(string targetStateName, TransitionBuilderAction<Completion> transitionBuildAction)
+            => AddDefaultTransition(targetStateName, transitionBuildAction) as ISubmachineTypedStateBuilder;
+
+        ISubmachineTypedStateBuilder IStateTransitionsBuilderBase<ISubmachineTypedStateBuilder>.AddInternalTransition<TEvent>(TransitionBuilderAction<TEvent> transitionBuildAction)
+            => AddInternalTransition<TEvent>(transitionBuildAction) as ISubmachineTypedStateBuilder;
         #endregion
     }
 }

--- a/Core/Stateflows/StateMachines/Registration/Builders/StateBuilder.cs
+++ b/Core/Stateflows/StateMachines/Registration/Builders/StateBuilder.cs
@@ -10,10 +10,15 @@ using Stateflows.StateMachines.Registration.Extensions;
 using Stateflows.StateMachines.Registration.Interfaces;
 using Stateflows.StateMachines.Registration.Interfaces.Base;
 using Stateflows.StateMachines.Registration.Interfaces.Internal;
+using Stateflows.Common.Events;
+using System.Collections.Generic;
 
 namespace Stateflows.StateMachines.Registration.Builders
 {
-    internal partial class StateBuilder : IStateBuilder, IStateBuilderInternal, ITypedStateBuilder
+    internal partial class StateBuilder : 
+        IStateBuilder, ISubmachineStateBuilder, 
+        ITypedStateBuilder, ISubmachineTypedStateBuilder, 
+        IStateBuilderInternal
     {
         public Vertex Vertex { get; }
 
@@ -105,6 +110,9 @@ namespace Stateflows.StateMachines.Registration.Builders
             if (typeof(TEvent) == typeof(Completion))
                 throw new Exception("Completion event cannot be deferred.");
 
+            if (typeof(TEvent) == typeof(Exit))
+                throw new Exception("Exit event cannot be deferred.");
+
             Vertex.DeferredEvents.Add(EventInfo<TEvent>.Name);
 
             return this;
@@ -150,6 +158,22 @@ namespace Stateflows.StateMachines.Registration.Builders
 
         ITypedStateBuilder IStateTransitionsBuilderBase<ITypedStateBuilder>.AddInternalTransition<TEvent>(TransitionBuilderAction<TEvent> transitionBuildAction)
             => AddInternalTransition<TEvent>(transitionBuildAction) as ITypedStateBuilder;
+
+        ITypedStateBuilder IStateUtilsBuilderBase<ITypedStateBuilder>.AddDeferredEvent<TEvent>()
+            => AddDeferredEvent<TEvent>() as ITypedStateBuilder;
+        #endregion
+
+        #region Submachine
+        public ISubmachineStateBuilder AddSubmachine(string submachineName, Dictionary<string, object> submachineInitialValues = null)
+        {
+            Vertex.SubmachineName = submachineName;
+            Vertex.SubmachineInitialValues = submachineInitialValues;
+
+            return this;
+        }
+
+        ISubmachineTypedStateBuilder IStateSubmachineBuilderBase<ISubmachineTypedStateBuilder>.AddSubmachine(string submachineName, Dictionary<string, object> submachineInitialValues)
+            => AddSubmachine(submachineName, submachineInitialValues) as ISubmachineTypedStateBuilder;
         #endregion
     }
 }

--- a/Core/Stateflows/StateMachines/Registration/Builders/StateMachineBuilder.cs
+++ b/Core/Stateflows/StateMachines/Registration/Builders/StateMachineBuilder.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
-using Stateflows.StateMachines.Models;
-using Stateflows.StateMachines.Extensions;
-using Stateflows.StateMachines.Interfaces;
-using Stateflows.StateMachines.Context.Classes;
-using Stateflows.StateMachines.Registration.Interfaces;
-using Stateflows.StateMachines.Registration.Interfaces.Base;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Stateflows.StateMachines.Registration.Interfaces.Internal;
 
 namespace Stateflows.StateMachines.Registration.Builders

--- a/Core/Stateflows/StateMachines/Registration/Builders/TypedStateMachineBuilder.cs
+++ b/Core/Stateflows/StateMachines/Registration/Builders/TypedStateMachineBuilder.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Stateflows.StateMachines.Context.Interfaces;
 using Stateflows.StateMachines.Extensions;
-using Stateflows.StateMachines.Interfaces;
 using Stateflows.StateMachines.Registration.Interfaces;
 using Stateflows.StateMachines.Registration.Interfaces.Base;
 using Stateflows.StateMachines.Registration.Interfaces.Internal;
@@ -21,70 +18,34 @@ namespace Stateflows.StateMachines.Registration.Builders
         }
 
         ITypedStateMachineBuilder IStateMachineBuilderBase<ITypedStateMachineBuilder>.AddState(string stateName, StateBuilderAction stateBuildAction)
-        {
-            AddState(stateName, stateBuildAction);
-            return this;
-        }
+            => AddState(stateName, stateBuildAction) as ITypedStateMachineBuilder;
 
         ITypedStateMachineBuilder IStateMachineBuilderBase<ITypedStateMachineBuilder>.AddCompositeState(string stateName, CompositeStateBuilderAction compositeStateBuildAction)
-        {
-            AddCompositeState(stateName, compositeStateBuildAction);
-            return this;
-        }
+            => AddCompositeState(stateName, compositeStateBuildAction) as ITypedStateMachineBuilder;
 
         ITypedStateMachineBuilder IStateMachineUtilsBuilderBase<ITypedStateMachineBuilder>.AddInterceptor<TInterceptor>()
-        {
-            AddInterceptor<TInterceptor>();
-            return this;
-        }
+            => AddInterceptor<TInterceptor>() as ITypedStateMachineBuilder;
 
         ITypedStateMachineBuilder IStateMachineUtilsBuilderBase<ITypedStateMachineBuilder>.AddObserver<TObserver>()
-        {
-            AddObserver<TObserver>();
-            return this;
-        }
+            => AddObserver<TObserver>() as ITypedStateMachineBuilder;
 
         ITypedStateMachineBuilder IStateMachineUtilsBuilderBase<ITypedStateMachineBuilder>.AddExceptionHandler<TExceptionHandler>()
-        {
-            AddExceptionHandler<TExceptionHandler>();
-            return this;
-        }
-
-        ITypedStateMachineBuilder IStateMachineEventsBuilderBase<ITypedStateMachineBuilder>.AddOnInitialize(Func<IStateMachineActionContext, Task> actionAsync)
-        {
-            AddOnInitialize(actionAsync);
-            return this;
-        }
+            => AddExceptionHandler<TExceptionHandler>() as ITypedStateMachineBuilder;
 
         ITypedStateMachineBuilder IStateMachineInitialBuilderBase<ITypedStateMachineBuilder>.AddInitialState(string stateName, StateBuilderAction stateBuildAction)
-        {
-            AddInitialState(stateName, stateBuildAction);
-            return this;
-        }
+            => AddInitialState(stateName, stateBuildAction) as ITypedStateMachineBuilder;
 
         ITypedStateMachineBuilder IStateMachineInitialBuilderBase<ITypedStateMachineBuilder>.AddInitialCompositeState(string stateName, CompositeStateBuilderAction compositeStateBuildAction)
-        {
-            AddInitialCompositeState(stateName, compositeStateBuildAction);
-            return this;
-        }
+            => AddInitialCompositeState(stateName, compositeStateBuildAction) as ITypedStateMachineBuilder;
 
         ITypedStateMachineInitialBuilder IStateMachineUtilsBuilderBase<ITypedStateMachineInitialBuilder>.AddInterceptor<TInterceptor>()
-        {
-            AddInterceptor<TInterceptor>();
-            return this;
-        }
+            => AddInterceptor<TInterceptor>() as ITypedStateMachineInitialBuilder;
 
         ITypedStateMachineInitialBuilder IStateMachineUtilsBuilderBase<ITypedStateMachineInitialBuilder>.AddObserver<TObserver>()
-        {
-            AddObserver<TObserver>(); 
-            return this;
-        }
+            => AddObserver<TObserver>() as ITypedStateMachineInitialBuilder;
 
         ITypedStateMachineInitialBuilder IStateMachineUtilsBuilderBase<ITypedStateMachineInitialBuilder>.AddExceptionHandler<TExceptionHandler>()
-        {
-            AddExceptionHandler<TExceptionHandler>(); 
-            return this;
-        }
+            => AddExceptionHandler<TExceptionHandler>() as ITypedStateMachineInitialBuilder;
     }
 }
 

--- a/Core/Stateflows/StateMachines/Registration/Constants.cs
+++ b/Core/Stateflows/StateMachines/Registration/Constants.cs
@@ -3,6 +3,7 @@
     internal class Constants
     {
         public static readonly string StatesStack = nameof(StatesStack);
+        public static readonly string ForceConsumed = nameof(ForceConsumed);
         public static readonly string DefaultTransitionTarget = string.Empty;
         public static readonly string CompletionEvent = string.Empty;
         public static readonly string SourceState = nameof(SourceState);

--- a/Core/Stateflows/StateMachines/Registration/Constants.cs
+++ b/Core/Stateflows/StateMachines/Registration/Constants.cs
@@ -14,6 +14,7 @@
         public static readonly string GlobalValues = nameof(GlobalValues);
         public static readonly string DeferredEvents = nameof(DeferredEvents);
         public static readonly string TimeEventIds = nameof(TimeEventIds);
+        public static readonly string SubmachineId = nameof(SubmachineId);
         public static readonly string Entry = nameof(Entry);
         public static readonly string OnEntry = nameof(OnEntry);
         public static readonly string OnEntryAsync = nameof(OnEntryAsync);

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Base/IStateEventsBuilderBase.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Base/IStateEventsBuilderBase.cs
@@ -1,20 +1,15 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Stateflows.Common;
 using Stateflows.StateMachines.Context.Interfaces;
 
 namespace Stateflows.StateMachines.Registration.Interfaces.Base
 {
-    public interface IStateBuilderBase<TReturn>
+    public interface IStateEventsBuilderBase<TReturn>
     {
         #region Events
         TReturn AddOnEntry(Func<IStateActionContext, Task> actionAsync);
 
         TReturn AddOnExit(Func<IStateActionContext, Task> actionAsync);
-        #endregion
-
-        #region Utils
-        TReturn AddDeferredEvent<TEvent>() where TEvent : Event, new();
         #endregion
     }
 }

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Base/IStateSubmachineBuilderBase.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Base/IStateSubmachineBuilderBase.cs
@@ -1,0 +1,12 @@
+﻿using Stateflows.Common;
+using System.Collections.Generic;
+
+namespace Stateflows.StateMachines.Registration.Interfaces.Base
+{
+    public interface IStateSubmachineBuilderBase<TReturn>
+    {
+        #region Submachine
+        TReturn AddSubmachine(string submachineName, Dictionary<string, object> submachineInitialValues = null);
+        #endregion
+    }
+}

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Base/IStateUtilsBuilderBase.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Base/IStateUtilsBuilderBase.cs
@@ -1,0 +1,11 @@
+﻿using Stateflows.Common;
+
+namespace Stateflows.StateMachines.Registration.Interfaces.Base
+{
+    public interface IStateUtilsBuilderBase<TReturn>
+    {
+        #region Utils
+        TReturn AddDeferredEvent<TEvent>() where TEvent : Event, new();
+        #endregion
+    }
+}

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/StateBuilder/Submachine/StateBuilderSubmachineTypedExtensions.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/StateBuilder/Submachine/StateBuilderSubmachineTypedExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Stateflows.StateMachines.Registration.Interfaces;
+
+namespace Stateflows.StateMachines
+{
+    public static class StateBuilderSubmachineTypedExtensions
+    {
+        public static ISubmachineStateBuilder AddSubmachine<TStateMachine>(this IStateBuilder builder, Dictionary<string, object> submachineInitialValues = null)
+            where TStateMachine : StateMachine
+            => builder.AddSubmachine(StateMachineInfo<TStateMachine>.Name, submachineInitialValues);
+    }
+}

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedCompositeStateBuilder/StateMachine/TypedCompositeStateBuilderTypedExtensions.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedCompositeStateBuilder/StateMachine/TypedCompositeStateBuilderTypedExtensions.cs
@@ -1,0 +1,56 @@
+﻿using Stateflows.StateMachines.Extensions;
+using Stateflows.StateMachines.Registration.Interfaces;
+using Stateflows.StateMachines.Registration.Interfaces.Internal;
+
+namespace Stateflows.StateMachines
+{
+    public static class TypedCompositeStateBuilderTypedExtensions
+    {
+        #region AddState
+        public static ITypedCompositeStateBuilder AddState<TState>(this ITypedCompositeStateBuilder builder, StateTransitionsBuilderAction stateBuildAction = null)
+            where TState : State
+            => builder.AddState<TState>(StateInfo<TState>.Name, stateBuildAction);
+
+        public static ITypedCompositeStateBuilder AddState<TState>(this ITypedCompositeStateBuilder builder, string stateName, StateTransitionsBuilderAction stateBuildAction = null)
+            where TState : State
+        {
+            var self = builder as ICompositeStateBuilderInternal;
+            self.Services.RegisterState<TState>();
+
+            return builder.AddState(
+                stateName,
+                b =>
+                {
+                    b.AddStateEvents<TState, IStateBuilder>();
+
+                    stateBuildAction?.Invoke(b as ITypedStateBuilder);
+                }
+            );
+        }
+        #endregion
+
+        #region AddCompositeState
+        public static ITypedCompositeStateBuilder AddCompositeState<TCompositeState>(this ITypedCompositeStateBuilder builder, CompositeStateTransitionsBuilderAction compositeStateBuildAction)
+            where TCompositeState : CompositeState
+            => builder.AddCompositeState<TCompositeState>(StateInfo<TCompositeState>.Name, compositeStateBuildAction);
+
+        public static ITypedCompositeStateBuilder AddCompositeState<TCompositeState>(this ITypedCompositeStateBuilder builder, string stateName, CompositeStateTransitionsBuilderAction compositeStateBuildAction)
+            where TCompositeState : CompositeState
+        {
+            var self = builder as ICompositeStateBuilderInternal;
+            self.Services.RegisterState<TCompositeState>();
+
+            return builder.AddCompositeState(
+                stateName,
+                b =>
+                {
+                    (b as ICompositeStateBuilder).AddStateEvents<TCompositeState, ICompositeStateBuilder>();
+                    (b as ICompositeStateBuilder).AddCompositeStateEvents<TCompositeState, ICompositeStateBuilder>();
+
+                    compositeStateBuildAction?.Invoke(b as ITypedCompositeStateInitialBuilder);
+                }
+            );
+        }
+        #endregion
+    }
+}

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedCompositeStateBuilder/StateMachine/TypedCompositeStateInitialBuilderTypedExtensions.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedCompositeStateBuilder/StateMachine/TypedCompositeStateInitialBuilderTypedExtensions.cs
@@ -1,0 +1,55 @@
+﻿using Stateflows.StateMachines.Extensions;
+using Stateflows.StateMachines.Registration.Interfaces;
+using Stateflows.StateMachines.Registration.Interfaces.Internal;
+
+namespace Stateflows.StateMachines
+{
+    public static class TypedCompositeStateInitialBuilderTypedExtensions
+    {
+        #region AddInitialState
+        public static ITypedCompositeStateBuilder AddInitialState<TState>(this ITypedCompositeStateInitialBuilder builder, StateTransitionsBuilderAction stateBuildAction = null)
+            where TState : State
+            => builder.AddInitialState<TState>(StateInfo<TState>.Name, stateBuildAction);
+
+        public static ITypedCompositeStateBuilder AddInitialState<TState>(this ITypedCompositeStateInitialBuilder builder, string stateName, StateTransitionsBuilderAction stateBuildAction = null)
+            where TState : State
+        {
+            var self = builder as ICompositeStateBuilderInternal;
+            self.Services.RegisterState<TState>();
+
+            return builder.AddInitialState(
+                stateName,
+                b =>
+                {
+                    b.AddStateEvents<TState, IStateBuilder>();
+
+                    stateBuildAction?.Invoke(b as ITypedStateBuilder);
+                }
+            );
+        }
+        #endregion
+
+        #region AddInitialCompositeState
+        public static ITypedCompositeStateBuilder AddInitialCompositeState<TState>(this ITypedCompositeStateInitialBuilder builder, CompositeStateTransitionsBuilderAction compositeStateBuildAction)
+            where TState : State
+            => builder.AddInitialCompositeState<TState>(StateInfo<TState>.Name, compositeStateBuildAction);
+
+        public static ITypedCompositeStateBuilder AddInitialCompositeState<TState>(this ITypedCompositeStateInitialBuilder builder, string stateName, CompositeStateTransitionsBuilderAction compositeStateBuildAction)
+            where TState : State
+        {
+            var self = builder as ICompositeStateBuilderInternal;
+            self.Services.RegisterState<TState>();
+
+            return builder.AddInitialCompositeState(
+                stateName,
+                b =>
+                {
+                    (b as ICompositeStateBuilder).AddStateEvents<TState, ICompositeStateBuilder>();
+
+                    compositeStateBuildAction?.Invoke(b as ITypedCompositeStateInitialBuilder);
+                }
+            );
+        }
+        #endregion
+    }
+}

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedCompositeStateBuilder/Transitions/TypedCompositeStateBuilderDefaultTransitionTypedExtensions.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedCompositeStateBuilder/Transitions/TypedCompositeStateBuilderDefaultTransitionTypedExtensions.cs
@@ -3,7 +3,7 @@ using Stateflows.StateMachines.Registration.Interfaces;
 
 namespace Stateflows.StateMachines
 {
-    public static class CompositeStateTransitionsBuilderDefaultTransitionTypedExtensions
+    public static class TypedCompositeStateBuilderDefaultTransitionTypedExtensions
     {
         public static ITypedCompositeStateBuilder AddDefaultTransition<TTransition, TTargetState>(this ITypedCompositeStateBuilder builder)
             where TTransition : Transition<Completion>

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedCompositeStateBuilder/Transitions/TypedCompositeStateBuilderInternalTransitionTypedExtensions.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedCompositeStateBuilder/Transitions/TypedCompositeStateBuilderInternalTransitionTypedExtensions.cs
@@ -4,9 +4,9 @@ using Stateflows.StateMachines.Registration.Interfaces;
 
 namespace Stateflows.StateMachines
 {
-    public static class StateTransitionsBuilderInternalTransitionTypedExtensions
+    public static class TypedCompositeStateBuilderInternalTransitionTypedExtensions
     {
-        public static ITypedStateBuilder AddInternalTransition<TEvent, TTransition>(this ITypedStateBuilder builder)
+        public static ITypedCompositeStateBuilder AddInternalTransition<TEvent, TTransition>(this ITypedCompositeStateBuilder builder)
             where TEvent : Event, new()
             where TTransition : Transition<TEvent>
             => builder.AddTransition<TEvent, TTransition>(Constants.DefaultTransitionTarget);

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedCompositeStateBuilder/Transitions/TypedCompositeStateBuilderTransitionTypedExtensions.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedCompositeStateBuilder/Transitions/TypedCompositeStateBuilderTransitionTypedExtensions.cs
@@ -6,15 +6,15 @@ using Stateflows.StateMachines.Registration.Interfaces.Internal;
 
 namespace Stateflows.StateMachines
 {
-    public static class StateTransitionsBuilderTransitionTypedExtensions
+    public static class TypedCompositeStateBuilderTransitionTypedExtensions
     {
-        public static ITypedStateBuilder AddTransition<TEvent, TTransition, TTargetState>(this ITypedStateBuilder builder)
+        public static ITypedCompositeStateBuilder AddTransition<TEvent, TTransition, TTargetState>(this ITypedCompositeStateBuilder builder)
             where TEvent : Event, new()
             where TTransition : Transition<TEvent>
             where TTargetState : State
             => AddTransition<TEvent, TTransition>(builder, StateInfo<TTargetState>.Name);
 
-        public static ITypedStateBuilder AddTransition<TEvent, TTransition>(this ITypedStateBuilder builder, string targetStateName)
+        public static ITypedCompositeStateBuilder AddTransition<TEvent, TTransition>(this ITypedCompositeStateBuilder builder, string targetStateName)
             where TEvent : Event, new()
             where TTransition : Transition<TEvent>
         {
@@ -29,7 +29,7 @@ namespace Stateflows.StateMachines
             return builder;
         }
 
-        public static ITypedStateBuilder AddTransition<TEvent, TTargetState>(this ITypedStateBuilder builder, TransitionBuilderAction<TEvent> transitionBuildAction = null)
+        public static ITypedCompositeStateBuilder AddTransition<TEvent, TTargetState>(this ITypedCompositeStateBuilder builder, TransitionBuilderAction<TEvent> transitionBuildAction = null)
             where TEvent : Event, new()
             where TTargetState : State
             => builder.AddTransition(StateInfo<TTargetState>.Name, transitionBuildAction);

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedStateBuilder/Submachine/TypedStateBuilderSubmachineTypedExtensions.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedStateBuilder/Submachine/TypedStateBuilderSubmachineTypedExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Stateflows.StateMachines.Registration.Interfaces;
+
+namespace Stateflows.StateMachines
+{
+    public static class TypedStateBuilderSubmachineTypedExtensions
+    {
+        public static ISubmachineTypedStateBuilder AddSubmachine<TStateMachine>(this ITypedStateBuilder builder, Dictionary<string, object> submachineInitialValues = null)
+            where TStateMachine : StateMachine
+            => builder.AddSubmachine(StateMachineInfo<TStateMachine>.Name, submachineInitialValues);
+    }
+}

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedStateBuilder/Transitions/TypedStateBuilderDefaultTransitionTypedExtensions.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedStateBuilder/Transitions/TypedStateBuilderDefaultTransitionTypedExtensions.cs
@@ -3,7 +3,7 @@ using Stateflows.StateMachines.Registration.Interfaces;
 
 namespace Stateflows.StateMachines
 {
-    public static class StateTransitionsBuilderDefaultTransitionTypedExtensions
+    public static class TypedStateBuilderDefaultTransitionTypedExtensions
     {
         public static ITypedStateBuilder AddDefaultTransition<TTransition, TTargetState>(this ITypedStateBuilder builder)
             where TTransition : Transition<Completion>

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedStateBuilder/Transitions/TypedStateBuilderInternalTransitionTypedExtensions.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedStateBuilder/Transitions/TypedStateBuilderInternalTransitionTypedExtensions.cs
@@ -4,9 +4,9 @@ using Stateflows.StateMachines.Registration.Interfaces;
 
 namespace Stateflows.StateMachines
 {
-    public static class CompositeStateTransitionsBuilderInternalTransitionTypedExtensions
+    public static class TypedStateBuilderInternalTransitionTypedExtensions
     {
-        public static ITypedCompositeStateBuilder AddInternalTransition<TEvent, TTransition>(this ITypedCompositeStateBuilder builder)
+        public static ITypedStateBuilder AddInternalTransition<TEvent, TTransition>(this ITypedStateBuilder builder)
             where TEvent : Event, new()
             where TTransition : Transition<TEvent>
             => builder.AddTransition<TEvent, TTransition>(Constants.DefaultTransitionTarget);

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedStateBuilder/Transitions/TypedStateBuilderTransitionTypedExtensions.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedStateBuilder/Transitions/TypedStateBuilderTransitionTypedExtensions.cs
@@ -6,15 +6,15 @@ using Stateflows.StateMachines.Registration.Interfaces.Internal;
 
 namespace Stateflows.StateMachines
 {
-    public static class CompositeStateTransitionsBuilderTransitionTypedExtensions
+    public static class TypedStateBuilderTransitionTypedExtensions
     {
-        public static ITypedCompositeStateBuilder AddTransition<TEvent, TTransition, TTargetState>(this ITypedCompositeStateBuilder builder)
+        public static ITypedStateBuilder AddTransition<TEvent, TTransition, TTargetState>(this ITypedStateBuilder builder)
             where TEvent : Event, new()
             where TTransition : Transition<TEvent>
             where TTargetState : State
             => AddTransition<TEvent, TTransition>(builder, StateInfo<TTargetState>.Name);
 
-        public static ITypedCompositeStateBuilder AddTransition<TEvent, TTransition>(this ITypedCompositeStateBuilder builder, string targetStateName)
+        public static ITypedStateBuilder AddTransition<TEvent, TTransition>(this ITypedStateBuilder builder, string targetStateName)
             where TEvent : Event, new()
             where TTransition : Transition<TEvent>
         {
@@ -29,7 +29,7 @@ namespace Stateflows.StateMachines
             return builder;
         }
 
-        public static ITypedCompositeStateBuilder AddTransition<TEvent, TTargetState>(this ITypedCompositeStateBuilder builder, TransitionBuilderAction<TEvent> transitionBuildAction = null)
+        public static ITypedStateBuilder AddTransition<TEvent, TTargetState>(this ITypedStateBuilder builder, TransitionBuilderAction<TEvent> transitionBuildAction = null)
             where TEvent : Event, new()
             where TTargetState : State
             => builder.AddTransition(StateInfo<TTargetState>.Name, transitionBuildAction);

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedStateMachineBuilder/StateMachine/TypedStateMachineBuilderTypedExtensions.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedStateMachineBuilder/StateMachine/TypedStateMachineBuilderTypedExtensions.cs
@@ -1,0 +1,56 @@
+﻿using Stateflows.StateMachines.Extensions;
+using Stateflows.StateMachines.Registration.Interfaces;
+using Stateflows.StateMachines.Registration.Interfaces.Internal;
+
+namespace Stateflows.StateMachines
+{
+    public static class TypedStateMachineBuilderTypedExtensions
+    {
+        #region AddState
+        public static ITypedStateMachineBuilder AddState<TState>(this ITypedStateMachineBuilder builder, StateTransitionsBuilderAction stateBuildAction = null)
+            where TState : State
+            => builder.AddState<TState>(StateInfo<TState>.Name, stateBuildAction);
+
+        public static ITypedStateMachineBuilder AddState<TState>(this ITypedStateMachineBuilder builder, string stateName, StateTransitionsBuilderAction stateBuildAction = null)
+            where TState : State
+        {
+            var self = builder as IStateMachineBuilderInternal;
+            self.Services.RegisterState<TState>();
+
+            return builder.AddState(
+                stateName,
+                b =>
+                {
+                    b.AddStateEvents<TState, IStateBuilder>();
+
+                    stateBuildAction?.Invoke(b as ITypedStateBuilder);
+                }
+            );
+        }
+        #endregion
+
+        #region AddCompositeState
+        public static ITypedStateMachineBuilder AddCompositeState<TCompositeState>(this ITypedStateMachineBuilder builder, CompositeStateTransitionsBuilderAction compositeStateBuildAction)
+            where TCompositeState : CompositeState
+            => builder.AddCompositeState<TCompositeState>(StateInfo<TCompositeState>.Name, compositeStateBuildAction);
+
+        public static ITypedStateMachineBuilder AddCompositeState<TCompositeState>(this ITypedStateMachineBuilder builder, string stateName, CompositeStateTransitionsBuilderAction compositeStateBuildAction)
+            where TCompositeState : CompositeState
+        {
+            var self = builder as IStateMachineBuilderInternal;
+            self.Services.RegisterState<TCompositeState>();
+
+            return builder.AddCompositeState(
+                stateName,
+                b =>
+                {
+                    (b as ICompositeStateBuilder).AddStateEvents<TCompositeState, ICompositeStateBuilder>();
+                    (b as ICompositeStateBuilder).AddCompositeStateEvents<TCompositeState, ICompositeStateBuilder>();
+
+                    compositeStateBuildAction?.Invoke(b as ITypedCompositeStateInitialBuilder);
+                }
+            );
+        }
+        #endregion
+    }
+}

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedStateMachineBuilder/StateMachine/TypedStateMachineInitialBuilderTypedExtensions.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/Extensions/TypedStateMachineBuilder/StateMachine/TypedStateMachineInitialBuilderTypedExtensions.cs
@@ -1,0 +1,55 @@
+﻿using Stateflows.StateMachines.Extensions;
+using Stateflows.StateMachines.Registration.Interfaces;
+using Stateflows.StateMachines.Registration.Interfaces.Internal;
+
+namespace Stateflows.StateMachines
+{
+    public static class TypedStateMachineInitialBuilderTypedExtensions
+    {
+        #region AddInitialState
+        public static ITypedStateMachineBuilder AddInitialState<TState>(this ITypedStateMachineInitialBuilder builder, StateTransitionsBuilderAction stateBuildAction = null)
+            where TState : State
+            => builder.AddInitialState<TState>(StateInfo<TState>.Name, stateBuildAction);
+
+        public static ITypedStateMachineBuilder AddInitialState<TState>(this ITypedStateMachineInitialBuilder builder, string stateName, StateTransitionsBuilderAction stateBuildAction = null)
+            where TState : State
+        {
+            var self = builder as IStateMachineBuilderInternal;
+            self.Services.RegisterState<TState>();
+
+            return builder.AddInitialState(
+                stateName,
+                b =>
+                {
+                    b.AddStateEvents<TState, IStateBuilder>();
+
+                    stateBuildAction?.Invoke(b as ITypedStateBuilder);
+                }
+            );
+        }
+        #endregion
+
+        #region AddInitialCompositeState
+        public static ITypedStateMachineBuilder AddInitialCompositeState<TState>(this ITypedStateMachineInitialBuilder builder, CompositeStateTransitionsBuilderAction compositeStateBuildAction)
+            where TState : State
+            => builder.AddInitialCompositeState<TState>(StateInfo<TState>.Name, compositeStateBuildAction);
+
+        public static ITypedStateMachineBuilder AddInitialCompositeState<TState>(this ITypedStateMachineInitialBuilder builder, string stateName, CompositeStateTransitionsBuilderAction compositeStateBuildAction)
+            where TState : State
+        {
+            var self = builder as IStateMachineBuilderInternal;
+            self.Services.RegisterState<TState>();
+
+            return builder.AddInitialCompositeState(
+                stateName,
+                b =>
+                {
+                    (b as ICompositeStateBuilder).AddStateEvents<TState, ICompositeStateBuilder>();
+
+                    compositeStateBuildAction?.Invoke(b as ITypedCompositeStateInitialBuilder);
+                }
+            );
+        }
+        #endregion
+    }
+}

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/ICompositeStateBuilder.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/ICompositeStateBuilder.cs
@@ -3,27 +3,30 @@
 namespace Stateflows.StateMachines.Registration.Interfaces
 {
     public interface ICompositeStateBuilder :
-        IStateBuilderBase<ICompositeStateBuilder>,
+        IStateEventsBuilderBase<ICompositeStateBuilder>,
+        IStateUtilsBuilderBase<ICompositeStateBuilder>,
         ICompositeStateBuilderBase<ICompositeStateBuilder>,
         IStateTransitionsBuilderBase<ICompositeStateBuilder>,
         IStateMachineBuilderBase<ICompositeStateBuilder>
     { }
 
     public interface ICompositeStateInitialBuilder :
-        IStateBuilderBase<ICompositeStateInitialBuilder>,
+        IStateEventsBuilderBase<ICompositeStateInitialBuilder>,
+        IStateUtilsBuilderBase<ICompositeStateInitialBuilder>,
         ICompositeStateBuilderBase<ICompositeStateInitialBuilder>,
         IStateTransitionsBuilderBase<ICompositeStateInitialBuilder>,
         IStateMachineInitialBuilderBase<ICompositeStateBuilder>
     { }
 
     public interface ITypedCompositeStateBuilder :
-        ICompositeStateBuilderBase<ITypedCompositeStateBuilder>,
+        IStateUtilsBuilderBase<ITypedCompositeStateBuilder>,
         IStateTransitionsBuilderBase<ITypedCompositeStateBuilder>,
         IStateMachineBuilderBase<ITypedCompositeStateBuilder>
     { }
 
     public interface ITypedCompositeStateInitialBuilder :
-        ICompositeStateBuilderBase<ITypedCompositeStateBuilder>,
+        IStateUtilsBuilderBase<ITypedCompositeStateInitialBuilder>,
+        IStateTransitionsBuilderBase<ITypedCompositeStateInitialBuilder>,
         IStateMachineInitialBuilderBase<ITypedCompositeStateBuilder>
     { }
 }

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/IStateBuilder.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/IStateBuilder.cs
@@ -2,12 +2,27 @@
 
 namespace Stateflows.StateMachines.Registration.Interfaces
 {
-    public partial interface IStateBuilder : 
-        IStateBuilderBase<IStateBuilder>,
-        IStateTransitionsBuilderBase<IStateBuilder>
+    public partial interface IStateBuilder :
+        IStateEventsBuilderBase<IStateBuilder>,
+        IStateUtilsBuilderBase<IStateBuilder>,
+        IStateTransitionsBuilderBase<IStateBuilder>,
+        IStateSubmachineBuilderBase<ISubmachineStateBuilder>
     { }
 
-    public partial interface ITypedStateBuilder : 
-        IStateTransitionsBuilderBase<ITypedStateBuilder>
+    public partial interface ISubmachineStateBuilder :
+        IStateEventsBuilderBase<ISubmachineStateBuilder>,
+        IStateUtilsBuilderBase<ISubmachineStateBuilder>,
+        IStateTransitionsBuilderBase<ISubmachineStateBuilder>
+    { }
+
+    public partial interface ITypedStateBuilder :
+        IStateUtilsBuilderBase<ITypedStateBuilder>,
+        IStateTransitionsBuilderBase<ITypedStateBuilder>,
+        IStateSubmachineBuilderBase<ISubmachineTypedStateBuilder>
+    { }
+
+    public partial interface ISubmachineTypedStateBuilder :
+        IStateUtilsBuilderBase<ISubmachineTypedStateBuilder>,
+        IStateTransitionsBuilderBase<ISubmachineTypedStateBuilder>
     { }
 }

--- a/Core/Stateflows/StateMachines/Registration/Interfaces/IStateMachineBuilder.cs
+++ b/Core/Stateflows/StateMachines/Registration/Interfaces/IStateMachineBuilder.cs
@@ -16,8 +16,7 @@ namespace Stateflows.StateMachines
 
     public interface ITypedStateMachineBuilder :
         IStateMachineBuilderBase<ITypedStateMachineBuilder>,
-        IStateMachineUtilsBuilderBase<ITypedStateMachineBuilder>,
-        IStateMachineEventsBuilderBase<ITypedStateMachineBuilder>
+        IStateMachineUtilsBuilderBase<ITypedStateMachineBuilder>
     { }
 
     public interface ITypedStateMachineInitialBuilder :

--- a/Core/Stateflows/StateMachines/StateMachinesDependencyInjection.cs
+++ b/Core/Stateflows/StateMachines/StateMachinesDependencyInjection.cs
@@ -138,7 +138,8 @@ namespace Stateflows.StateMachines
                     .AddSingleton<IStateMachineEventHandler, InitializationHandler>()
                     .AddSingleton<IStateMachineEventHandler, InitializedHandler>()
                     .AddSingleton<IStateMachineEventHandler, CurrentStateHandler>()
-                    .AddSingleton<IStateMachineEventHandler, ExpectedEventsHandler>();
+                    .AddSingleton<IStateMachineEventHandler, ExpectedEventsHandler>()
+                    .AddSingleton<IStateMachineEventHandler, ExitHandler>();
             }
 
             if (!Registers.TryGetValue(stateflowsBuilder, out var result))

--- a/Tests/StateMachine/StateMachine.IntegrationTests/Tests/Deferral.cs
+++ b/Tests/StateMachine/StateMachine.IntegrationTests/Tests/Deferral.cs
@@ -26,6 +26,18 @@ namespace StateMachine.IntegrationTests.Tests
                     )
                     .AddState("state3")
                 )
+
+                .AddStateMachine("nested", b => b
+                    .AddInitialCompositeState("state1", b => b
+                        .AddInitialState("state1.1", b => b
+                            .AddDeferredEvent<OtherEvent>()
+                            .AddTransition<SomeEvent>("state1.2")
+                        )
+                        .AddState("state1.2")
+                        .AddTransition<OtherEvent>("state2")
+                    )
+                    .AddState("state2")
+                )
                 ;
         }
 
@@ -52,6 +64,35 @@ namespace StateMachine.IntegrationTests.Tests
             Assert.IsTrue(someConsumed);
             Assert.IsFalse(otherConsumed);
             Assert.AreEqual("state3", currentState);
+        }
+
+        [TestMethod]
+        public async Task NestedDeferral()
+        {
+            var initialized = false;
+            string currentState = "";
+            var otherConsumed1 = false;
+            var otherConsumed2 = false;
+            var someConsumed = false;
+
+            if (Locator.TryLocateStateMachine(new StateMachineId("nested", "x"), out var sm))
+            {
+                initialized = await sm.InitializeAsync();
+
+                otherConsumed1 = await sm.SendAsync(new OtherEvent());
+
+                someConsumed = await sm.SendAsync(new SomeEvent());
+
+                otherConsumed2 = await sm.SendAsync(new OtherEvent());
+
+                currentState = (await sm.GetCurrentStateAsync()).Name;
+            }
+
+            Assert.IsTrue(initialized);
+            Assert.IsTrue(someConsumed);
+            Assert.IsFalse(otherConsumed1);
+            Assert.IsFalse(otherConsumed2);
+            Assert.AreEqual("state2", currentState);
         }
     }
 }

--- a/Tests/StateMachine/StateMachine.IntegrationTests/Tests/Scale.cs
+++ b/Tests/StateMachine/StateMachine.IntegrationTests/Tests/Scale.cs
@@ -1,0 +1,45 @@
+using StateMachine.IntegrationTests.Utils;
+
+namespace StateMachine.IntegrationTests.Tests
+{
+    [TestClass]
+    public class Scale : StateflowsTestClass
+    {
+        [TestInitialize]
+        public override void Initialize()
+            => base.Initialize();
+
+        [TestCleanup]
+        public override void Cleanup()
+            => base.Cleanup();
+
+        protected override void InitializeStateflows(IStateflowsBuilder builder)
+        {
+            builder
+                .AddStateMachine("scale", b => b
+                    .AddInitialState("state1")
+                )
+                ;
+        }
+
+        [TestMethod]
+        public async Task ProcessingInScale()
+        {
+            var sequence = Enumerable
+                .Range(0, 10000)
+                .Select(i => Locator.TryLocateStateMachine(new StateMachineId("scale", i.ToString()), out var sm)
+                    ? sm
+                    : null
+                )
+                .Where(sm => sm is not null)
+                .Select(sm => sm.InitializeAsync())
+                .ToArray();
+
+            var results = await Task.WhenAll(sequence);
+
+            var badResults = results.Count(i => !i);
+
+            Assert.AreEqual(0, badResults);
+        }
+    }
+}

--- a/Tests/StateMachine/StateMachine.IntegrationTests/Tests/Submachine.cs
+++ b/Tests/StateMachine/StateMachine.IntegrationTests/Tests/Submachine.cs
@@ -1,0 +1,65 @@
+using StateMachine.IntegrationTests.Utils;
+
+namespace StateMachine.IntegrationTests.Tests
+{
+    [TestClass]
+    public class Submachine : StateflowsTestClass
+    {
+        [TestInitialize]
+        public override void Initialize()
+            => base.Initialize();
+
+        [TestCleanup]
+        public override void Cleanup()
+            => base.Cleanup();
+
+        protected override void InitializeStateflows(IStateflowsBuilder builder)
+        {
+            builder
+                .AddStateMachine("submachine", b => b
+                    .AddInitialState("state1", b => b
+                        .AddSubmachine("nested")
+                        .AddTransition<SomeEvent>("state2")
+                    )
+                    .AddState("state2")
+                )
+
+                .AddStateMachine("nested", b => b
+                    .AddInitialState("state1", b => b
+                        .AddTransition<SomeEvent>("state2")
+                    )
+                    .AddState("state2")
+                )
+                ;
+        }
+
+        [TestMethod]
+        public async Task SimpleSubmachine()
+        {
+            var initialized = false;
+            string currentState1 = "";
+            string currentState2 = "";
+            var someConsumed1 = false;
+            var someConsumed2 = false;
+
+            if (Locator.TryLocateStateMachine(new StateMachineId("submachine", "x"), out var sm))
+            {
+                initialized = await sm.InitializeAsync();
+
+                someConsumed1 = await sm.SendAsync(new SomeEvent());
+
+                currentState1 = (await sm.GetCurrentStateAsync()).Name;
+
+                someConsumed2 = await sm.SendAsync(new SomeEvent());
+
+                currentState2 = (await sm.GetCurrentStateAsync()).Name;
+            }
+
+            Assert.IsTrue(initialized);
+            Assert.IsTrue(someConsumed1);
+            Assert.AreEqual("state1", currentState1);
+            Assert.IsTrue(someConsumed2);
+            Assert.AreEqual("state2", currentState2);
+        }
+    }
+}

--- a/Tests/StateMachine/StateMachine.IntegrationTests/Tests/Submachine.cs
+++ b/Tests/StateMachine/StateMachine.IntegrationTests/Tests/Submachine.cs
@@ -17,6 +17,7 @@ namespace StateMachine.IntegrationTests.Tests
         {
             builder
                 .AddStateMachine("submachine", b => b
+                    .AddExecutionSequenceObserver()
                     .AddInitialState("state1", b => b
                         .AddSubmachine("nested")
                         .AddTransition<SomeEvent>("state2")
@@ -25,10 +26,11 @@ namespace StateMachine.IntegrationTests.Tests
                 )
 
                 .AddStateMachine("nested", b => b
-                    .AddInitialState("state1", b => b
-                        .AddTransition<SomeEvent>("state2")
+                    .AddExecutionSequenceObserver()
+                    .AddInitialState("stateA", b => b
+                        .AddTransition<SomeEvent>("stateB")
                     )
-                    .AddState("state2")
+                    .AddState("stateB")
                 )
                 ;
         }
@@ -55,6 +57,14 @@ namespace StateMachine.IntegrationTests.Tests
                 currentState2 = (await sm.GetCurrentStateAsync()).Name;
             }
 
+            ExecutionSequence.Verify(b => b
+                .StateEntry("state1")
+                .StateEntry("stateA")
+                .StateExit("stateA")
+                .StateEntry("stateB")
+                .StateExit("stateB")
+                .StateEntry("state2")
+            );
             Assert.IsTrue(initialized);
             Assert.IsTrue(someConsumed1);
             Assert.AreEqual("state1", currentState1);


### PR DESCRIPTION
- submachines in states
- new interceptor events: beforeDispatchEvent and afterDispatchEvent
- interceptor's beforeProcessEvent and afterProcessEvent are now not intercepting events handled by eventHandlers (standard ones like InitializationRequest etc.)